### PR TITLE
Use abstract classes to avoid repeated code

### DIFF
--- a/main.py
+++ b/main.py
@@ -68,17 +68,16 @@ def main():
             strategy.process_next(symbol.get_candlesticks(NEXT))
             signal = strategy.check_signal()
             
-            match signal.get('action'):
-                case 1:
-                    if(account.get_positions()):
-                        trade_executor.close_all_positions(symbol.get_symbol_info_bid(), symbol.get_symbol_info_ask(),20)
-                    trade_executor.place_order(symbol.get_symbol_name(),signal,symbol.get_symbol_info_ask(),20) 
-                case -1:
-                    if(account.get_positions()):
-                        trade_executor.close_all_positions(symbol.get_symbol_info_bid(), symbol.get_symbol_info_ask(),20)
-                    trade_executor.place_order(symbol.get_symbol_name(),signal,symbol.get_symbol_info_bid(),20) 
-                case 0:
-                    trade_executor.do_nothing()
+            if signal.get('action') == 1:
+                if(account.get_positions()):
+                    trade_executor.close_all_positions(symbol.get_symbol_info_bid(), symbol.get_symbol_info_ask(),20)
+                trade_executor.place_order(symbol.get_symbol_name(),signal,symbol.get_symbol_info_ask(),20) 
+            elif signal.get('action') == -1:
+                if(account.get_positions()):
+                    trade_executor.close_all_positions(symbol.get_symbol_info_bid(), symbol.get_symbol_info_ask(),20)
+                trade_executor.place_order(symbol.get_symbol_name(),signal,symbol.get_symbol_info_bid(),20) 
+            else:
+                trade_executor.do_nothing()
              
             strategy.record_action()
             action_writer.print_action()

--- a/main.py
+++ b/main.py
@@ -68,16 +68,17 @@ def main():
             strategy.process_next(symbol.get_candlesticks(NEXT))
             signal = strategy.check_signal()
             
-            if signal.get('action') == 1:
-                if(account.get_positions()):
-                    trade_executor.close_all_positions(symbol.get_symbol_info_bid(), symbol.get_symbol_info_ask(),20)
-                trade_executor.place_order(symbol.get_symbol_name(),signal,symbol.get_symbol_info_ask(),20) 
-            elif signal.get('action') == -1:
-                if(account.get_positions()):
-                    trade_executor.close_all_positions(symbol.get_symbol_info_bid(), symbol.get_symbol_info_ask(),20)
-                trade_executor.place_order(symbol.get_symbol_name(),signal,symbol.get_symbol_info_bid(),20) 
-            else:
-                trade_executor.do_nothing()
+            match signal.get('action'):
+                case 1:
+                    if(account.get_positions()):
+                        trade_executor.close_all_positions(symbol.get_symbol_info_bid(), symbol.get_symbol_info_ask(),20)
+                    trade_executor.place_order(symbol.get_symbol_name(),signal,symbol.get_symbol_info_ask(),20) 
+                case -1:
+                    if(account.get_positions()):
+                        trade_executor.close_all_positions(symbol.get_symbol_info_bid(), symbol.get_symbol_info_ask(),20)
+                    trade_executor.place_order(symbol.get_symbol_name(),signal,symbol.get_symbol_info_bid(),20) 
+                case 0:
+                    trade_executor.do_nothing()
              
             strategy.record_action()
             action_writer.print_action()

--- a/src/abstract_account.py
+++ b/src/abstract_account.py
@@ -1,0 +1,25 @@
+import abc
+import pandas as pd
+
+class AbstractAccount(abc.ABC):
+    
+    balance: float
+    profit: float
+
+    ticket: int # do we use this ticket variable in live implementation ?
+    symbol: object # should we pass a symbol object to this class ? 
+    
+    positions_df: pd.DataFrame
+    positions = dict()
+
+    @abc.abstractmethod
+    def get_positions(self) -> dict:
+        pass
+
+    @abc.abstractmethod
+    def get_account_balance(self) -> float:
+        pass
+    
+    @abc.abstractmethod
+    def get_account_profit(self) -> float:
+        pass

--- a/src/abstract_context.py
+++ b/src/abstract_context.py
@@ -1,0 +1,20 @@
+import abc
+
+# Meta trade interface - to abstract away and isolate MetaTrader SDK calls
+class AbstractContext(abc.ABC):
+    
+    json_settings: dict
+    credentials: dict
+
+    def __init__(self, json_settings: dict, credentials: dict):
+        """
+        Initializes MetaTrader object
+        :param json_settings: A dict containing symbol trading details.
+        :param credentials: A dict containing MetaTrader5 login details.
+        """
+        self.json_settings = json_settings
+        self.credentials = credentials
+
+    @abc.abstractmethod
+    def connect(self) -> bool:
+        pass

--- a/src/abstract_symbols.py
+++ b/src/abstract_symbols.py
@@ -1,0 +1,43 @@
+import abc
+import pandas as pd
+
+from datetime import timezone
+
+class AbstractSymbols(abc.ABC):
+
+    candles_df: pd.DataFrame
+    current_time: timezone
+    mt5_timeframe: int
+    symbol: str 
+    timeframe: str
+
+    start_pos = 0
+
+    def __init__(self, symbol, timeframe):
+        self.symbol = symbol
+        self.timeframe = timeframe
+        
+    def get_symbol_name(self) -> str:
+        return self.symbol
+    
+    def get_symbol_info_bid(self) -> float:
+        symbol_info_tick = self.get_symbol_info_tick()
+        symbol_info_bid = symbol_info_tick['bid']
+        return symbol_info_bid
+
+    def get_symbol_info_ask(self) -> float:
+        symbol_info_tick = self.get_symbol_info_tick()
+        symbol_info_ask = symbol_info_tick['ask']
+        return symbol_info_ask
+    
+    @abc.abstractmethod
+    def get_candlesticks(self, num_candlesticks) -> object:
+        pass
+
+    @abc.abstractmethod
+    def get_candlestick_time(self) -> int:
+        pass
+
+    @abc.abstractmethod
+    def get_symbol_info_tick(self) -> dict:
+        pass

--- a/src/abstract_trade_execution.py
+++ b/src/abstract_trade_execution.py
@@ -14,7 +14,7 @@ class AbstractTradeExecution(abc.ABC):
         self.current_risk_per_trade = self.account_info.get_account_balance() * self.RISK
         return self.current_risk_per_trade
 
-    def calc_lot_size(self, price) -> float:
+    def calc_lot_size(self, price: float) -> float:
         self.current_risk_per_trade = self.calc_risk_per_trade()
         self.current_lot_size = self.current_risk_per_trade / price
         return self.current_lot_size
@@ -34,8 +34,4 @@ class AbstractTradeExecution(abc.ABC):
 
     @abc.abstractmethod
     def close_position(self) -> bool:
-        pass
-
-    @abc.abstractmethod
-    def calc_lot_size(self) -> float:
         pass

--- a/src/abstract_trade_execution.py
+++ b/src/abstract_trade_execution.py
@@ -1,0 +1,41 @@
+import abc
+
+class AbstractTradeExecution(abc.ABC):
+    
+    RISK = .02
+    current_risk_per_trade = 0.0
+    current_lot_size = 0.0
+    account_info: object
+    
+    def __init__(self, account: object):
+        self.account_info = account
+        
+    def calc_risk_per_trade(self) -> float:
+        self.current_risk_per_trade = self.account_info.get_account_balance() * self.RISK
+        return self.current_risk_per_trade
+
+    def calc_lot_size(self, price) -> float:
+        self.current_risk_per_trade = self.calc_risk_per_trade()
+        self.current_lot_size = self.current_risk_per_trade / price
+        return self.current_lot_size
+
+    def close_all_positions(self, bid, ask, deviation) -> bool:
+        positions = self.account_info.get_positions()
+        for position in positions:
+            self.close_position(position, bid, ask, deviation)
+    
+    def do_nothing(self):
+        print("No actionable trades!")
+        return
+    
+    @abc.abstractmethod
+    def place_order(self) -> bool:
+        pass
+
+    @abc.abstractmethod
+    def close_position(self) -> bool:
+        pass
+
+    @abc.abstractmethod
+    def calc_lot_size(self) -> float:
+        pass

--- a/src/account_factory.py
+++ b/src/account_factory.py
@@ -1,4 +1,4 @@
-from src.interfaces import IAccount
+from src.abstract_account import AbstractAccount
 from src.account_mt5 import AccountMT5
 from src.account_sim import AccountSimulator
 
@@ -9,7 +9,7 @@ class AccountFactory():
     def __init__(self, production: bool):
         self.production = production
 
-    def create_account(self):
+    def create_account(self) -> AbstractAccount:
         if (self.production):
             return AccountMT5()
         else:

--- a/src/account_mt5.py
+++ b/src/account_mt5.py
@@ -1,24 +1,13 @@
 import MetaTrader5 as mt5
 import pandas as pd
 
-from src.interfaces import IAccount
+from src.abstract_account import AbstractAccount
 
-class AccountMT5(IAccount):
-
-    balance: float
-    profit: float
-
-    ticket: int # do we use this ticket variable in live implementation ?
-    symbol: object # should we pass a symbol object to this class ? 
+class AccountMT5(AbstractAccount):
     
-    positions_df: pd.DataFrame
-    positions: dict
-
-    def __init__(self) -> None:
+    def __init__(self):
         self.balance = self.get_account_balance()
         self.profit = self.get_account_profit()
-        self.positions = dict()
-        # self.positions_df = pd.DataFrame() # Not used
         
     def get_account_info(self) -> dict:
         account_info_dict = mt5.account_info()._asdict()

--- a/src/account_sim.py
+++ b/src/account_sim.py
@@ -1,27 +1,17 @@
 import pandas as pd
 
-from src.interfaces import IAccount
+from src.abstract_account import AbstractAccount
 
 from datetime import datetime
 from datetime import timedelta
 from datetime import timezone
 
-class AccountSimulator(IAccount):
-    
-    balance: float
-    profit: float
-
-    ticket: int
-    symbol: object # should we pass a symbol object to this class ? 
-    
-    positions_df: pd.DataFrame
-    positions: dict
+class AccountSimulator(AbstractAccount):
 
     def __init__(self, balance, profit) -> None:
         self.balance = balance
         self.profit = profit
         self.ticket = 500000000
-        self.positions = dict()
         self.positions_df = pd.DataFrame('symbol','ticket','time','type','volume','price','current_price','profit') 
 
     def update_balance(self, profit) -> None:
@@ -85,6 +75,11 @@ class AccountSimulator(IAccount):
         if(type == 'sell'):
             current_price = self.symbol.get_symbol_info_ask()
         return current_price
+    
+    def get_account_profit(self) -> float:
+        account_info_dict = self.get_account_info()
+        profit = account_info_dict['profit']
+        return profit
     
     # Option 1, use the current time as the trade time when running trade executor in mock
     def get_date_time_now(self) -> datetime:

--- a/src/account_sim.py
+++ b/src/account_sim.py
@@ -8,9 +8,9 @@ from datetime import timezone
 
 class AccountSimulator(AbstractAccount):
 
-    def __init__(self, balance, profit) -> None:
-        self.balance = balance
-        self.profit = profit
+    def __init__(self):
+        self.balance = 100
+        self.profit = 100
         self.ticket = 500000000
         self.positions_df = pd.DataFrame('symbol','ticket','time','type','volume','price','current_price','profit') 
 

--- a/src/context_factory.py
+++ b/src/context_factory.py
@@ -1,5 +1,5 @@
 
-from src.interfaces import IContext
+from src.abstract_context import AbstractContext
 from src.context_mt5 import ContextMT5
 from src.context_sim import ContextSimulator
 
@@ -10,7 +10,7 @@ class ContextFactory():
     def __init__(self, production: bool):
         self.production = production
 
-    def create_context(self, json_settings: dict, credentials: dict) -> IContext:
+    def create_context(self, json_settings: dict, credentials: dict) -> AbstractContext:
         if (self.production):
             return ContextMT5(json_settings, credentials)
         else:

--- a/src/context_mt5.py
+++ b/src/context_mt5.py
@@ -1,21 +1,9 @@
 import MetaTrader5 as mt5
 import pandas as pd
 
-from src.interfaces import IContext
+from src.abstract_context import AbstractContext
 
-class ContextMT5(IContext): 
-
-    json_settings: dict
-    credentials: dict
-
-    def __init__(self, json_settings: dict, credentials: dict):
-        """
-        Initializes MetaTrader object
-        :param json_settings: A dict containing symbol trading details.
-        :param credentials: A dict containing MetaTrader5 login details.
-        """
-        self.json_settings = json_settings
-        self.credentials = credentials
+class ContextMT5(AbstractContext): 
 
     def connect(self) -> bool:
         """

--- a/src/context_sim.py
+++ b/src/context_sim.py
@@ -1,19 +1,7 @@
 
-from src.interfaces import IContext
+from src.abstract_context import AbstractContext
 
-class ContextSimulator(IContext):
-
-    json_settings: dict
-    credentials: dict    
-
-    def __init__(self, json_settings: dict, credentials: dict):
-        """
-        Initializes MetaTrader object
-        :param json_settings: A dict containing symbol trading details.
-        :param credentials: A dict containing MetaTrader5 login details.
-        """
-        self.json_settings = json_settings
-        self.credentials = credentials
+class ContextSimulator(AbstractContext):
 
     def connect(self) -> bool:
         # always happy

--- a/src/interfaces.py
+++ b/src/interfaces.py
@@ -1,12 +1,5 @@
 import abc
 
-# Meta trade interface - to abstract away and isolate MetaTrader SDK calls
-class IContext(abc.ABC):
-
-    @abc.abstractmethod
-    def connect(self) -> bool:
-        pass
-
 class IStrategy(abc.ABC):
 
     @abc.abstractmethod
@@ -26,44 +19,6 @@ class IStrategy(abc.ABC):
     def check_signal(self) -> bool:
         pass
     """
-
-class ISymbols(abc.ABC):
-    
-    @abc.abstractmethod
-    def get_candlesticks(self, num_candlesticks) -> object:
-        pass
-
-    @abc.abstractmethod
-    def get_candlestick_time(self) -> int:
-        pass
-
-    @abc.abstractmethod
-    def get_symbol_info_tick(self) -> dict:
-        pass
-
-class ITradeExecutor(abc.ABC):
-
-    @abc.abstractmethod
-    def place_order(self) -> bool:
-        pass
-
-    @abc.abstractmethod
-    def close_position(self) -> bool:
-        pass
-
-    @abc.abstractmethod
-    def calc_lot_size(self) -> float:
-        pass
-
-class IAccount(abc.ABC):
-
-    @abc.abstractmethod
-    def get_positions(self) -> dict:
-        pass
-
-    @abc.abstractmethod
-    def get_account_balance(self) -> float:
-        pass
 
     
 

--- a/src/symbols_factory.py
+++ b/src/symbols_factory.py
@@ -1,5 +1,4 @@
-
-from src.interfaces import ISymbols
+from src.abstract_symbols import AbstractSymbols
 from src.symbols_mt5 import SymbolsMT5
 from src.symbols_sim import SymbolsSimulator
 
@@ -10,7 +9,7 @@ class SymbolsFactory():
     def __init__(self, production: bool):
         self.production = production
 
-    def create_symbol(self, symbol, timeframe, candles_mock_location = "mock/candlesticks.csv", ticks_mock_location="mock/ticks.csv") -> ISymbols:
+    def create_symbol(self, symbol, timeframe, candles_mock_location = "mock/candlesticks.csv", ticks_mock_location="mock/ticks.csv") -> AbstractSymbols:
         if (self.production):
             return SymbolsMT5(symbol, timeframe)
         else:

--- a/src/symbols_mt5.py
+++ b/src/symbols_mt5.py
@@ -3,30 +3,22 @@ import pandas as pd
 from enum import Enum
 import MetaTrader5 as mt5
 
-from src.interfaces import ISymbols
+from src.abstract_symbols import AbstractSymbols
 
 from datetime import datetime
 from datetime import timedelta
 from datetime import timezone
 
-class SymbolsMT5(ISymbols):
+class SymbolsMT5(AbstractSymbols):
 
     candles: np.array
-    candles_df: pd.DataFrame
-
-    symbol: str 
-    mt5_timeframe: int
-    timeframe: str
-    start_pos: int
     
     # used only by ticks retrieval method, not the same as candlestick/system time inside EmaStrategy object
     current_time: timezone
 
     def __init__(self, symbol: str, timeframe: str) -> None:
-        self.symbol = symbol
-        self.timeframe = timeframe
+        super().__init__(symbol, timeframe)
         self.mt5_timeframe = self.get_mt5_timeframe(timeframe)
-        self.start_pos = 0
 
     def set_symbol(self, symbol: str, timeframe: str) -> None:
         self.symbol = symbol
@@ -59,25 +51,12 @@ class SymbolsMT5(ISymbols):
     def get_symbol_info_tick(self) -> dict:
         symbol_info_tick = mt5.symbol_info_tick(self.symbol)._asdict()
         return symbol_info_tick
-    
-    def get_symbol_info_bid(self) -> float:
-        symbol_info_tick = self.get_symbol_info_tick()
-        symbol_info_bid = symbol_info_tick['bid']
-        return symbol_info_bid
-
-    def get_symbol_info_ask(self) -> float:
-        symbol_info_tick = self.get_symbol_info_tick()
-        symbol_info_ask = symbol_info_tick['ask']
-        return symbol_info_ask
 
     def get_ticks(self, num_ticks, current_time = 0) -> pd.DataFrame:
         self.current_time = current_time
         ticks = mt5.copy_ticks_from(self.symbol, self.current_time, num_ticks, mt5.COPY_TICKS_ALL)
         ticks_df = pd.DataFrame(ticks)
         return ticks_df
-    
-    def get_symbol_name(self) -> str:
-        return self.symbol
 
     def get_mt5_timeframe(self, timeframe: str):
         """

--- a/src/symbols_sim.py
+++ b/src/symbols_sim.py
@@ -2,36 +2,20 @@ import numpy as np
 import pandas as pd
 from enum import Enum
 
-from src.interfaces import ISymbols
-
-from datetime import datetime
-from datetime import timedelta
+from src.abstract_symbols import AbstractSymbols
 from datetime import timezone
 
+class SymbolsSimulator(AbstractSymbols):
 
-class SymbolsSimulator(ISymbols):
-
-    ### Unique to Mock class ###
     candles_df_master: pd.DataFrame
     ticks_df_master: pd.DataFrame
     counter: object
     mock_location: str
-    ### #################### ###
-
-    candles_df: pd.DataFrame
-
-    symbol: str 
-    mt5_timeframe: int # do we use this in mock ?
-    timeframe: str # do we use this in mock ?
-    start_pos: int # how do we use start pos in mock?
-
     current_time: timezone # do we use this in mock ?
 
     def __init__(self, symbol, timeframe, candles_mock_location="mock/candlesticks.csv", ticks_mock_location="mock/ticks.csv"):
-        self.symbol = symbol
-        self.timeframe = timeframe
+        super().__init__(symbol, timeframe)
         self.mt5_timeframe = self.get_mt5_timeframe(timeframe) # do we need this?
-        self.start_pos = 0 # how do we use start pos in mock? # counter unique to mock 
         
         self.ticks_df_master = self.get_ticks_from_csv(ticks_mock_location)
         self.candles_df_master = self.get_candlesticks_from_csv(candles_mock_location)
@@ -65,21 +49,8 @@ class SymbolsSimulator(ISymbols):
         tick = tick_df.to_dict('list')
         return tick
 
-    def get_symbol_info_bid(self) -> float:
-        symbol_info_tick = self.get_symbol_info_tick()
-        symbol_info_bid = symbol_info_tick['bid'][0]
-        return symbol_info_bid
-
-    def get_symbol_info_ask(self) -> float:
-        symbol_info_tick = self.get_symbol_info_tick()
-        symbol_info_ask = symbol_info_tick['ask']
-        return symbol_info_ask
-
     def get_ticks(self, num_ticks, current_time = 0) -> pd.DataFrame:
         pass
-
-    def get_symbol_name(self) -> str:
-        return self.symbol
 
     ### Implementation unique to mock method ###
     # Get candlesticks master file

--- a/src/trade_bot.py
+++ b/src/trade_bot.py
@@ -1,13 +1,14 @@
 
 import threading
 import time
-from src.interfaces import IStrategy, IContext
+from src.interfaces import IStrategy
+from src.abstract_context import AbstractContext
 
 class TradeBot(object):
     
     # instance variables (passed in the constructor)
     strategy: IStrategy
-    meta_trader: IContext
+    meta_trader: AbstractContext
 
     # instance variables (created internally)
     thread: threading.Thread
@@ -16,7 +17,7 @@ class TradeBot(object):
     def __init__(
             self,
             strategy: IStrategy,
-            meta_trader: IContext):
+            meta_trader: AbstractContext):
         self.strategy = strategy
         self.meta_trader = meta_trader
         self.thread = threading.Thread(target=trade_bot_thread_func, args=(self,))

--- a/src/trade_execution_factory.py
+++ b/src/trade_execution_factory.py
@@ -1,4 +1,4 @@
-from src.interfaces import ITradeExecutor
+from src.abstract_trade_execution import AbstractTradeExecution
 from src.trade_execution_mt5 import TradeExecutorMT5
 from src.trade_execution_sim import TradeExecutorSimulator
 
@@ -9,7 +9,7 @@ class TradeExecutionFactory():
     def __init__(self, production: bool):
         self.production = production
 
-    def create_trade_executor(self, account: object):
+    def create_trade_executor(self, account: object) -> AbstractTradeExecution:
         if (self.production):
             return TradeExecutorMT5(account)
         else:

--- a/src/trade_execution_mt5.py
+++ b/src/trade_execution_mt5.py
@@ -1,7 +1,9 @@
 import MetaTrader5 as mt5
 from enum import Enum
 
-class TradeExecutorMT5():
+from src.abstract_trade_execution import AbstractTradeExecution
+
+class TradeExecutorMT5(AbstractTradeExecution):
 
     def place_order(self, symbol, signal, price, deviation) -> bool:
 

--- a/src/trade_execution_mt5.py
+++ b/src/trade_execution_mt5.py
@@ -1,28 +1,7 @@
-import pandas as pd
 import MetaTrader5 as mt5
 from enum import Enum
 
-RISK = .02
-
 class TradeExecutorMT5():
-
-    current_risk_per_trade: float 
-    current_lot_size: float
-    account_info: object
-
-    def __init__(self, account: object) -> None:
-        self.current_risk_per_trade = 0.0
-        self.current_lot_size = 0.0
-        self.account_info = account
-
-    def calc_risk_per_trade(self) -> float:
-        self.current_risk_per_trade = self.account_info.get_account_balance() * RISK
-        return self.current_risk_per_trade
-    
-    def calc_lot_size(self, price) -> float:
-        self.current_risk_per_trade = self.calc_risk_per_trade()
-        self.current_lot_size = self.current_risk_per_trade / price
-        return self.current_lot_size
 
     def place_order(self, symbol, signal, price, deviation) -> bool:
 
@@ -105,15 +84,6 @@ class TradeExecutorMT5():
 
         print("2. order_send done, ", result) 
         print("closed POSITION_TICKET={}, profit {}".format(position.ticket, position.profit))
-    
-    def close_all_positions(self, bid, ask, deviation) -> bool:
-        positions = self.account_info.get_positions()
-        for position in positions:
-            self.close_position(position, bid, ask, deviation)
-    
-    def do_nothing(self) -> None:
-        print("No actionable trades!")
-        return
     
 class OrderType(Enum):
     buy = mt5.ORDER_TYPE_BUY

--- a/src/trade_execution_sim.py
+++ b/src/trade_execution_sim.py
@@ -1,34 +1,11 @@
 import pandas as pd
 
-
-
-RISK = .02
-
 class TradeExecutorSimulator():
-
-    current_risk_per_trade: float 
-    current_lot_size: float
 
     current_profit: float # have we defined yet?
     
     positions: dict
     positions_df: pd.DataFrame # necessary?
-
-    account_info: object
-
-    def __init__(self, account: object) -> None:
-        self.current_risk_per_trade = 0.0
-        self.current_lot_size = 0.0
-        self.account_info = account
-
-    def calc_risk_per_trade(self) -> float:
-        self.current_risk_per_trade = self.account_info.get_account_balance() * RISK
-        return self.current_risk_per_trade
-
-    def calc_lot_size(self, price) -> float:
-        self.current_risk_per_trade = self.calc_risk_per_trade()
-        self.current_lot_size = self.current_risk_per_trade / price
-        return self.current_lot_size
 
     def place_order(self, symbol, signal, price, deviation) -> bool:
         volume = self.calc_lot_size(price)
@@ -46,8 +23,3 @@ class TradeExecutorSimulator():
         self.account_info.update_balance(profit)
         self.account_info.update_profit(profit)
         return True
-    
-    def close_all_positions(self, bid, ask, deviation) -> bool:
-        positions = self.account_info.get_positions()
-        for position in positions:
-            self.close_position(position, bid, ask, deviation)

--- a/src/trade_execution_sim.py
+++ b/src/trade_execution_sim.py
@@ -1,6 +1,8 @@
 import pandas as pd
 
-class TradeExecutorSimulator():
+from src.abstract_trade_execution import AbstractTradeExecution
+
+class TradeExecutorSimulator(AbstractTradeExecution):
 
     current_profit: float # have we defined yet?
     


### PR DESCRIPTION
Moves the code that is used in both mt5 and simulator classes to abstract classes (derived from the interfaces) to avoid repeating code.