### PR TITLE
Cleaning up import ordering

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,12 +1,12 @@
-from src.json_reader import JsonReader
-from src.action_writer import ActionWriter
-from src.ema_strategy import EmaStrategy
-from src.symbol_factory import SymbolFactory
-from src.context_factory import ContextFactory
-from src.account_factory import AccountFactory
-from src.trade_executor_factory import TradeExecutionFactory
-
 import pandas as pd
+
+from src.account_factory import AccountFactory
+from src.action_writer import ActionWriter
+from src.context_factory import ContextFactory
+from src.ema_strategy import EmaStrategy
+from src.json_reader import JsonReader
+from src.symbol_factory import SymbolFactory
+from src.trade_executor_factory import TradeExecutionFactory
 
 # Path to MetaTrader5 login details.
 ACCOUNT_SETTINGS_PATH = "pkg/settings.json"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+isort==5.13.2
 MetaTrader5==5.0.45
 mock==5.1.0
 numpy==1.26.1

--- a/src/account_factory.py
+++ b/src/account_factory.py
@@ -1,6 +1,7 @@
-from src.interfaces import IAccount
 from src.account_mt5 import AccountMT5
 from src.account_sim import AccountSimulator
+from src.interfaces import IAccount
+
 
 class AccountFactory():
 
@@ -9,7 +10,7 @@ class AccountFactory():
     def __init__(self, production: bool):
         self.production = production
 
-    def create_account(self, symbol, balance=100000, profit=0, action_writer = object):
+    def create_account(self, symbol, balance=100000, profit=0, action_writer = object) -> IAccount:
         if (self.production):
             return AccountMT5()
         else:

--- a/src/account_sim.py
+++ b/src/account_sim.py
@@ -1,11 +1,10 @@
+from collections import namedtuple
+from datetime import datetime, timedelta, timezone
+
 import pandas as pd
 
 from src.interfaces import IAccount
 
-from datetime import datetime
-from datetime import timedelta
-from datetime import timezone
-from collections import namedtuple
 
 class AccountSimulator(IAccount):
     

--- a/src/action_writer.py
+++ b/src/action_writer.py
@@ -1,8 +1,7 @@
+from datetime import datetime, timedelta, timezone
+
 import pandas as pd
 
-from datetime import datetime
-from datetime import timedelta
-from datetime import timezone
 
 class ActionWriter():
 

--- a/src/context_factory.py
+++ b/src/context_factory.py
@@ -1,7 +1,8 @@
 
-from src.interfaces import IContext
 from src.context_mt5 import ContextMT5
 from src.context_sim import ContextSimulator
+from src.interfaces import IContext
+
 
 class ContextFactory():
 

--- a/src/context_mt5.py
+++ b/src/context_mt5.py
@@ -2,6 +2,7 @@ import MetaTrader5 as mt5
 
 from src.interfaces import IContext
 
+
 class ContextMT5(IContext): 
 
     json_settings: dict

--- a/src/context_sim.py
+++ b/src/context_sim.py
@@ -1,6 +1,7 @@
 
 from src.interfaces import IContext
 
+
 class ContextSimulator(IContext):
 
     json_settings: dict

--- a/src/ema_strategy.py
+++ b/src/ema_strategy.py
@@ -1,13 +1,11 @@
-import pandas as pd
-import talib as ta
 import time
 import winsound
-from datetime import datetime
-from datetime import timedelta
-from datetime import timezone
+from datetime import datetime, timedelta, timezone
+
+import pandas as pd
+import talib as ta
 
 from src.interfaces import IStrategy
-from src.action_writer import ActionWriter
 
 SMOOTHENING = 2
 

--- a/src/interfaces.py
+++ b/src/interfaces.py
@@ -1,5 +1,6 @@
 import abc
 
+
 # Meta trade interface - to abstract away and isolate MetaTrader SDK calls
 class IContext(abc.ABC):
 

--- a/src/json_reader.py
+++ b/src/json_reader.py
@@ -1,5 +1,6 @@
-import os
 import json
+import os
+
 
 class JsonReader(object):
 

--- a/src/symbol_factory.py
+++ b/src/symbol_factory.py
@@ -2,6 +2,7 @@ from src.interfaces import ISymbol
 from src.symbol_mt5 import SymbolMT5
 from src.symbol_sim import SymbolSimulator
 
+
 class SymbolFactory():
 
     production: bool

--- a/src/symbol_mt5.py
+++ b/src/symbol_mt5.py
@@ -1,13 +1,12 @@
+from datetime import datetime, timedelta, timezone
+from enum import Enum
+
+import MetaTrader5 as mt5
 import numpy as np
 import pandas as pd
-from enum import Enum
-import MetaTrader5 as mt5
 
 from src.interfaces import ISymbol
 
-from datetime import datetime
-from datetime import timedelta
-from datetime import timezone
 
 class SymbolMT5(ISymbol):
 

--- a/src/symbol_sim.py
+++ b/src/symbol_sim.py
@@ -1,10 +1,10 @@
-import numpy as np
-import pandas as pd
+from datetime import timezone
 from enum import Enum
 
-from src.interfaces import ISymbol
+import numpy as np
+import pandas as pd
 
-from datetime import timezone
+from src.interfaces import ISymbol
 
 
 class SymbolSimulator(ISymbol):

--- a/src/trade_bot.py
+++ b/src/trade_bot.py
@@ -1,7 +1,9 @@
 
 import threading
 import time
-from src.interfaces import IStrategy, IContext
+
+from src.interfaces import IContext, IStrategy
+
 
 class TradeBot(object):
     

--- a/src/trade_executor_factory.py
+++ b/src/trade_executor_factory.py
@@ -2,6 +2,7 @@ from src.interfaces import IAccount
 from src.trade_executor_mt5 import TradeExecutorMT5
 from src.trade_executor_sim import TradeExecutorSimulator
 
+
 class TradeExecutionFactory():
 
     production: bool

--- a/src/trade_executor_mt5.py
+++ b/src/trade_executor_mt5.py
@@ -1,5 +1,6 @@
-import MetaTrader5 as mt5
 from enum import Enum
+
+import MetaTrader5 as mt5
 
 from src.shared_helper_functions import calc_lot_size
 

--- a/tests/account_mt5_test.py
+++ b/tests/account_mt5_test.py
@@ -1,9 +1,11 @@
+import unittest
 from collections import namedtuple
+
+import pytest
+
 from mock import patch
 from src.account_mt5 import AccountMT5
 
-import pytest
-import unittest
 
 class AccountMT5Tests(unittest.TestCase):
     

--- a/tests/context_mt5_test.py
+++ b/tests/context_mt5_test.py
@@ -1,9 +1,11 @@
+import json
 import unittest
+
+import pytest
+
 from mock import patch
 from src.context_mt5 import ContextMT5
 
-import json
-import pytest
 
 class ContextMT5Tests(unittest.TestCase):
     

--- a/tests/shared_helper_functions_test.py
+++ b/tests/shared_helper_functions_test.py
@@ -1,4 +1,5 @@
 from src.shared_helper_functions import calc_lot_size
 
+
 def test_calc_lot_size():
     assert calc_lot_size(0.1, 50) == 10

--- a/tests/symbols_mt5_test.py
+++ b/tests/symbols_mt5_test.py
@@ -1,9 +1,11 @@
+import unittest
 from collections import namedtuple
+
+import pytest
+
 from mock import patch
 from src.symbol_mt5 import SymbolMT5
 
-import pytest
-import unittest
 
 class SymbolMT5Tests(unittest.TestCase):
     

--- a/tests/trade_executor_mt5_test.py
+++ b/tests/trade_executor_mt5_test.py
@@ -1,11 +1,12 @@
+import sys
+import unittest
 from collections import namedtuple
+
+import pytest
+
 from mock import MagicMock, patch
 from src.account_mt5 import AccountMT5
 from src.trade_executor_mt5 import TradeExecutorMT5
-
-import pytest
-import sys
-import unittest
 
 sys.modules['mt5'] = MagicMock()
 


### PR DESCRIPTION
Use isort library to guarantee the ordering of how the imports are listed.